### PR TITLE
Update RegEx to check if subject does not end with dot

### DIFF
--- a/commit-police.js
+++ b/commit-police.js
@@ -107,7 +107,7 @@
     function doesNotEndWithDot(message) {
         // must necessarily end with an alpha-numeric value
         // or a new line... thanks, Bitbucket!@#$
-        return /[a-z0-9\n\s]$/i.test(message);
+        return /[a-z0-9]$/i.test(message.replace(/(\s+|\n+)$/, ''));
     }
 
     init();


### PR DESCRIPTION
Add in RegEx the replace command to remove spaces or new lines. Previous RegEx treated commit messages ended with "." as valid commit message.
